### PR TITLE
Update audio.py

### DIFF
--- a/app/endpoints/audio.py
+++ b/app/endpoints/audio.py
@@ -65,18 +65,17 @@ async def audio_transcriptions(
     logger.info("Reading file …")
     reading_start = time.perf_counter()
     with tempfile.NamedTemporaryFile(
-        delete=False, suffix=os.path.splitext(file.filename)[1]
+        suffix=os.path.splitext(file.filename)[1]
     ) as temp_file:
         temp_file_path = temp_file.name
         content = await file.read()
         temp_file.write(content)
 
-    reading_time = time.perf_counter() - reading_start
-    logger.info("Reading time: %.3fs", reading_time)
+        reading_time = time.perf_counter() - reading_start
+        logger.info("Reading time: %.3fs", reading_time)
 
-    logger.info("Loading audio file to whisper…")
-    audio = whisperx.load_audio(temp_file_path)
-    os.remove(temp_file_path)
+        logger.info("Loading audio file to whisper…")
+        audio = whisperx.load_audio(temp_file_path)
 
     result = transcribe(audio, settings, language)
 


### PR DESCRIPTION
The temp file is written, then whisperx.load_audio() is called, then os.remove() is called. If load_audio raises an exception the remove call is never reached, leaking the file on disk. Any crash, unsupported format, or corrupt audio leaves a dangling temp file.
 
In audio.py, the endpoint writes a temp file, then calls whisperx.load_audio(), then deletes the file. If load_audio throws — due to a corrupt upload, unsupported codec, or an OOM error — the os.remove() call is never reached and the file sits on disk permanently. The fix is a try/finally block so deletion is guaranteed regardless of what happens